### PR TITLE
match the browser timeout with job timeout

### DIFF
--- a/adapters/fetchers/jshttp/jshttp.go
+++ b/adapters/fetchers/jshttp/jshttp.go
@@ -117,6 +117,11 @@ func (o *jsFetch) Fetch(ctx context.Context, job scrapemate.IJob) scrapemate.Res
 				Error: err,
 			}
 		}
+
+		// match the browser default timeout to the job timeout
+		if job.GetTimeout() > 0 {
+			page.SetDefaultTimeout(float64(job.GetTimeout().Milliseconds()))
+		}
 	}
 
 	defer page.Close()


### PR DESCRIPTION
Some of the jobs that I scrape are timing out because of playwright 30 seconds default timeout. I want to use the job timeout to also increase playwrights default.