### PR TITLE
fix(jshttp): bound page.Close() with a timeout to survive a wedged driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - JavaScript rendering is now Playwright-only
 - `scrapemateapp.WithBrowserEngine()` and `scrapemateapp.WithRodStealth()` remain as deprecated no-op compatibility shims
 
+### Fixed
+
+- `jshttp`: `page.Close()` is now time-bounded (5 s default via `closeWithTimeout`).
+  A wedged Playwright driver (e.g. EPIPE after a browser crash) could make
+  `page.Close()` block indefinitely, stalling the worker goroutine and preventing
+  the fetcher from returning. The cleanup goroutine is now abandoned after the
+  deadline so the worker is freed. Backward-compatible — no API change; in the
+  healthy case `Close` returns within milliseconds and the deadline is never reached.
+
 ## [1.0.0] - 2026-01-06
 
 ### Breaking Changes

--- a/adapters/fetchers/jshttp/jshttp.go
+++ b/adapters/fetchers/jshttp/jshttp.go
@@ -29,6 +29,7 @@ func closeWithTimeout(closer func() error, d time.Duration) {
 
 	go func() {
 		_ = closer()
+
 		close(done)
 	}()
 

--- a/adapters/fetchers/jshttp/jshttp.go
+++ b/adapters/fetchers/jshttp/jshttp.go
@@ -3,6 +3,7 @@ package jshttp
 import (
 	"context"
 	"errors"
+	"time"
 
 	"github.com/playwright-community/playwright-go"
 
@@ -11,6 +12,31 @@ import (
 )
 
 var _ scrapemate.HTTPFetcher = (*jsFetch)(nil)
+
+// closeTimeout is the maximum time allowed for a Playwright page.Close() before
+// the caller abandons it. A wedged Playwright driver (e.g. EPIPE after a browser
+// crash) can make Close block forever; abandoning it frees the worker goroutine
+// at the cost of leaking the underlying resource.
+const closeTimeout = 5 * time.Second
+
+// closeWithTimeout runs closer in a background goroutine and returns when it
+// completes or when d elapses, whichever comes first. On timeout the goroutine
+// is abandoned (it will finish on its own if the driver recovers). Without this
+// bound, a hung Close propagates through the worker WaitGroup and prevents the
+// caller from being unblocked even by context cancellation.
+func closeWithTimeout(closer func() error, d time.Duration) {
+	done := make(chan struct{})
+
+	go func() {
+		_ = closer()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(d):
+	}
+}
 
 type JSFetcherOptions struct {
 	Headless           bool
@@ -229,7 +255,7 @@ func (o *jsFetch) fetchWithPageSlot(ctx context.Context, job scrapemate.IJob) sc
 		return scrapemate.Response{Error: err}
 	}
 
-	defer page.Close()
+	defer closeWithTimeout(func() error { return page.Close() }, closeTimeout)
 
 	if job.GetTimeout() > 0 {
 		page.SetDefaultTimeout(float64(job.GetTimeout().Milliseconds()))

--- a/adapters/fetchers/jshttp/jshttp_boundedclose_internal_test.go
+++ b/adapters/fetchers/jshttp/jshttp_boundedclose_internal_test.go
@@ -21,15 +21,16 @@ func TestCloseWithTimeout_FastClose(t *testing.T) {
 
 func TestCloseWithTimeout_HungClose(t *testing.T) {
 	start := time.Now()
+
 	closeWithTimeout(func() error {
 		select {} // block forever
 	}, 200*time.Millisecond)
+
 	if elapsed := time.Since(start); elapsed > time.Second {
 		t.Fatalf("closeWithTimeout did not abandon a hung closer in time: %s", elapsed)
 	}
 }
 
-func TestCloseWithTimeout_ErrorIgnored(t *testing.T) {
+func TestCloseWithTimeout_ErrorIgnored(_ *testing.T) {
 	closeWithTimeout(func() error { return errors.New("boom") }, time.Second)
-	// No assertion beyond "does not panic / does not hang".
 }

--- a/adapters/fetchers/jshttp/jshttp_boundedclose_test.go
+++ b/adapters/fetchers/jshttp/jshttp_boundedclose_test.go
@@ -1,0 +1,35 @@
+package jshttp
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestCloseWithTimeout_FastClose(t *testing.T) {
+	done := make(chan struct{})
+	go func() {
+		closeWithTimeout(func() error { return nil }, time.Second)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("closeWithTimeout did not return for a fast closer")
+	}
+}
+
+func TestCloseWithTimeout_HungClose(t *testing.T) {
+	start := time.Now()
+	closeWithTimeout(func() error {
+		select {} // block forever
+	}, 200*time.Millisecond)
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("closeWithTimeout did not abandon a hung closer in time: %s", elapsed)
+	}
+}
+
+func TestCloseWithTimeout_ErrorIgnored(t *testing.T) {
+	closeWithTimeout(func() error { return errors.New("boom") }, time.Second)
+	// No assertion beyond "does not panic / does not hang".
+}


### PR DESCRIPTION
## What

`page.Close()` in the `jshttp` Playwright fetcher is now time-bounded (5s default) via a small `closeWithTimeout` helper.

## Why

If the Playwright driver wedges — e.g. `EPIPE` after a browser process crash — `page.Close()` can block indefinitely. Because `Close` runs (deferred) inside the fetch path, an unbounded block stalls the worker goroutine and prevents the fetcher from returning, even after the caller cancels its context. In a long-running worker pool a single wedged close can therefore freeze a slot.

## How

`closeWithTimeout` runs the close in a goroutine and abandons it after the deadline. In the wedge case the goroutine leaks (it finishes on its own if the driver recovers), but the worker goroutine is freed. In the healthy case `Close` returns within milliseconds and the deadline is never reached.

- **Backward-compatible:** no API change; behaviour is identical for a healthy driver.
- **Tests:** unit tests for fast-close, hung-close (deadline fires, caller is freed), and error-returning close — no browser required.
