### PR TITLE
Allow unauthenticated proxies in local_proxy.go

### DIFF
--- a/adapters/fetchers/jshttp/local_proxy.go
+++ b/adapters/fetchers/jshttp/local_proxy.go
@@ -113,9 +113,10 @@ func StartAuthProxy(proxyURL, username, password string) (*AuthProxy, error) {
 		return nil, fmt.Errorf("proxy URL cannot be empty")
 	}
 
-	if username == "" || password == "" {
-		return nil, fmt.Errorf("username and password are required")
-	}
+	// Allow unauthenticated proxies
+	// if username == "" || password == "" {
+	// 	return nil, fmt.Errorf("username and password are required")
+	// }
 
 	upstreamURL, err := url.Parse(proxyURL)
 	if err != nil {


### PR DESCRIPTION
Commented out the requirement for username and password for proxy authentication, allowing unauthenticated proxies.